### PR TITLE
Added memcached support for the new TTL feature

### DIFF
--- a/deploy/docker-compose/insecure-memcached/docker-compose.yml
+++ b/deploy/docker-compose/insecure-memcached/docker-compose.yml
@@ -1,15 +1,25 @@
-version: "3.0"
-
 services:
-  memcached:
-    image: memcached
-    restart: always
-    expose:
-      - "11211"
-
   yopass:
-    image: jhaals/yopass
+    image: TassiloPitrasch/yopass:latest
+    container_name: yopass
     restart: always
+    networks:
+      - yopass_internal
+      - yopass_external
     ports:
-      - "127.0.0.1:80:80"
-    command: "--memcached=memcached:11211 --port 80"
+      - "80:80"
+    command: "--database=memcached --memcached=yopass_memcached:11211 --port 80"
+
+  memcached:
+    image: memcached:latest
+    container_name: yopass_memcached
+    restart: always
+    networks:
+      - yopass_internal
+
+networks:
+  yopass_internal:
+    internal: true
+  yopass_external:
+    driver: bridge
+    internal: false

--- a/pkg/server/memcached.go
+++ b/pkg/server/memcached.go
@@ -20,6 +20,7 @@ type Memcached struct {
 // Get key in memcached
 func (m *Memcached) Get(key string) (yopass.Secret, error) {
 	var s yopass.Secret
+	s.TTL = -1
 
 	r, err := m.Client.Get(key)
 	if err != nil {

--- a/website/public/locales/en.json
+++ b/website/public/locales/en.json
@@ -46,7 +46,10 @@
   "secret": {
     "titleFile": "File downloaded",
     "titleMessage": "Decrypted message",
-    "buttonCopy": "Copy"
+    "buttonCopy": "Copy",
+    "expiresOn": "This secret will expire on {{formattedExpiryDate}}. Be sure to copy/download it until then!",
+    "expireUnkown": "Could not parse the secret's remaining time-to-live. Be sure to copy/download the secret NOW!",
+    "oneTime": "This secret is one-time only. It's not stored anywhere anymore. Be sure to copy/download it NOW!"
   },
   "delete": {
     "buttonDelete": "Delete",

--- a/website/src/displaySecret/DisplaySecret.tsx
+++ b/website/src/displaySecret/DisplaySecret.tsx
@@ -143,12 +143,9 @@ const DisplaySecret = () => {
     );
   }
   if (value) {
-    var expiryDate = new Date();
-    expiryDate.setMilliseconds(data.ttl / 1000000);
-
     return (
       <>
-        <Secret secret={value.data as string} fileName={value.filename} expiryDate={expiryDate} oneTime={data.one_time}/>
+        <Secret secret={value.data as string} fileName={value.filename} ttl={data.ttl} oneTime={data.one_time}/>
         {data.one_time ? null : <DeleteSecret url={url} />}
       </>
     );

--- a/website/src/displaySecret/Secret.tsx
+++ b/website/src/displaySecret/Secret.tsx
@@ -111,27 +111,42 @@ const DownloadSecret = ({
 const Secret = ({
   secret,
   fileName,
-  expiryDate,
+  ttl,
   oneTime,
 }: {
   readonly secret: string;
   readonly fileName?: string;
-  readonly expiryDate: Date;
+  readonly ttl: number;
   readonly oneTime: boolean;
 }) => {
+  const { t } = useTranslation();
   if (! oneTime) {
     const timeZone = Intl.DateTimeFormat().resolvedOptions().timeZone;
     const DateTimeFormat = Intl.DateTimeFormat.supportedLocalesOf([i18n.language], {localeMatcher: "lookup"}) ? i18n.language : "en-US";
 
-    var formattedDate = new Intl.DateTimeFormat(DateTimeFormat, {
+    var expiryDate = new Date();
+    try {
+      
+      if (ttl < 0) {
+        throw RangeError;
+      }
+      else {
+        expiryDate.setMilliseconds(ttl / 1000000);
+      }
+
+      var formattedExpiryDate = new Intl.DateTimeFormat(DateTimeFormat, {
         dateStyle: 'full',
         timeStyle: 'long',
         timeZone: timeZone,
       }).format(expiryDate);
-    var notice = "This secret will expire on " + formattedDate + ". Be sure to copy/download it until then!";
+      var notice = t('secret.expiresOn', {formattedExpiryDate: formattedExpiryDate});;
+    }
+    catch(RangeError) {
+      var notice = t('secret.expireUnkown');
+    }
   }
   else {
-    var notice = "This secret is one-time only. It's not stored anywhere anymore. Be sure to copy/download it NOW!";
+    var notice = t('secret.oneTime');
   }
   if (fileName) {
     return <DownloadSecret fileName={fileName} secret={secret} notice={notice}/>;


### PR DESCRIPTION
Changes related to the support of a memcached database:

1. As getting the TTL of memcached entries is not trivial and storing the expiry time in the secret itself is - IMHO - not feasible, the memcached client sets the TTL of returned secrets to -1. The website displays a corresponding notice.
2. Additionally, the parsing of the expiry date in general was made a little more resilient.
3. Deployment of the Docker container with the memcached database was also enhanced.

The notice(s) also use the translation mechanism now.
