### PR TITLE
Set hard-coded value for TTL in dynamo client

### DIFF
--- a/deploy/cdk/main.go
+++ b/deploy/cdk/main.go
@@ -48,6 +48,7 @@ func NewDynamo(tableName string) server.Database {
 // Get item from dynamo
 func (d *Dynamo) Get(key string) (yopass.Secret, error) {
 	var s yopass.Secret
+	s.TTL = -1
 	input := &dynamodb.GetItemInput{
 		Key: map[string]*dynamodb.AttributeValue{
 			"id": {


### PR DESCRIPTION
AFAIK Dynamo database doesn't have an easy/reliable way to retrieve the TTL of a stored entry, so the default value of -1 is returned.