### PR TITLE
Allowed disabling the QR-code and file upload features 

### DIFF
--- a/website/README.md
+++ b/website/README.md
@@ -47,3 +47,5 @@ PUBLIC_URL='https://my-domain.com' REACT_APP_BACKEND_URL='http://api.my-domain.c
 
 - `YOPASS_DISABLE_FEATURES_CARDS=1` - Allows disabling Features cards
 - `YOPASS_DISABLE_ONE_CLICK_LINK=1` - Allows disabling "One-click link" support
+- `YOPASS_DISABLE_FILE_UPLOAD=1` - Allows disabling the file upload function
+- `YOPASS_DISABLE_QR_CODE=1` - Allows disabling the display of the secret as a QR-code

--- a/website/src/Routing.tsx
+++ b/website/src/Routing.tsx
@@ -5,11 +5,14 @@ import DisplaySecret from './displaySecret/DisplaySecret';
 import Upload from './createSecret/Upload';
 
 export const Routing = () => {
+  const fileUpload = process.env.YOPASS_DISABLE_FILE_UPLOAD !== '1';
   const oneClickLink = process.env.YOPASS_DISABLE_ONE_CLICK_LINK !== '1';
   return (
     <Routes>
       <Route path="/" element={<CreateSecret />} />
-      <Route path="/upload" element={<Upload />} />
+      {fileUpload && (
+        <Route path="/upload" element={<Upload />} />
+      )}
       {oneClickLink && (
         <Route path="/:format/:key/:password" element={<DisplaySecret />} />
       )}

--- a/website/src/createSecret/Upload.tsx
+++ b/website/src/createSecret/Upload.tsx
@@ -16,6 +16,8 @@ import { useTranslation } from 'react-i18next';
 import { useForm } from 'react-hook-form';
 import { Grid, Typography } from '@mui/material';
 
+const fileUpload = process.env.YOPASS_DISABLE_FILE_UPLOAD !== '1';
+
 const Upload = () => {
   const maxSize = 1024 * 500;
   const [error, setError] = useState('');

--- a/website/src/displaySecret/Secret.tsx
+++ b/website/src/displaySecret/Secret.tsx
@@ -11,6 +11,7 @@ import QRCode from 'react-qr-code';
 const RenderSecret = ({ secret, notice }: { readonly secret: string; readonly notice: string }) => {
   const { t } = useTranslation();
   const [copy, copyToClipboard] = useCopyToClipboard();
+  const qrCode = process.env.YOPASS_DISABLE_QR_CODE !== '1';
   const [showQr, setShowQr] = useState(false);
 
   return (
@@ -40,19 +41,23 @@ const RenderSecret = ({ secret, notice }: { readonly secret: string; readonly no
       >
         {secret}
       </Typography>
-      <Button onClick={() => setShowQr(!showQr)}>
-        {showQr ? t('secret.hideQrCode') : t('secret.showQrCode')}
-      </Button>
-      <Box
-        sx={{
-          display: showQr ? 'flex' : 'none',
-          justifyContent: 'center',
-          alignItems: 'center',
-          margin: 5,
-        }}
-      >
-        <QRCode size={150} style={{ height: 'auto' }} value={secret} />
-      </Box>
+      {qrCode && (
+        <>
+          <Button onClick={() => setShowQr(!showQr)}>
+            {showQr ? t('secret.hideQrCode') : t('secret.showQrCode')}
+          </Button>
+          <Box
+            sx={{
+              display: showQr ? 'flex' : 'none',
+              justifyContent: 'center',
+              alignItems: 'center',
+              margin: 5,
+            }}
+          >
+            <QRCode size={150} style={{ height: 'auto' }} value={secret} />
+          </Box>
+        </>
+      )}
       <Typography
         id="notice"
         data-test-id="preformatted-text-message"

--- a/website/src/shared/Header.tsx
+++ b/website/src/shared/Header.tsx
@@ -9,6 +9,7 @@ export const Header = () => {
   const base = process.env.PUBLIC_URL || '';
   const home = base + '/#/';
   const upload = base + '/#/upload';
+  const fileUpload = process.env.YOPASS_DISABLE_FILE_UPLOAD !== '1';
   // Replace home with base in first href below to force reload when clicking on logo
   return (
     <AppBar position="static" color="transparent" sx={{ marginBottom: 4 }}>
@@ -30,20 +31,24 @@ export const Header = () => {
             />
           </Typography>
         </Link>
-        <Box
-          sx={{
-            marginLeft: 'auto',
-          }}
-        >
-          <Button
-            component={Link}
-            href={isOnUploadPage ? home : upload}
-            variant="contained"
-            color="primary"
-          >
-            {isOnUploadPage ? t('header.buttonHome') : t('header.buttonUpload')}
-          </Button>
-        </Box>
+        {fileUpload && (
+          <>
+            <Box
+              sx={{
+                marginLeft: 'auto',
+              }}
+             >
+               <Button
+                 component={Link}
+                 href={isOnUploadPage ? home : upload}
+                 variant="contained"
+                 color="primary"
+               >
+                 {isOnUploadPage ? t('header.buttonHome') : t('header.buttonUpload')}
+               </Button>
+             </Box>
+          </>
+        )}
       </Toolbar>
     </AppBar>
   );

--- a/website/vite.config.ts
+++ b/website/vite.config.ts
@@ -35,6 +35,10 @@ export default defineConfig(() => {
           process.env.YOPASS_DISABLE_FEATURES_CARDS,
         YOPASS_DISABLE_ONE_CLICK_LINK:
           process.env.YOPASS_DISABLE_ONE_CLICK_LINK,
+        YOPASS_DISABLE_FILE_UPLOAD:
+          process.env.YOPASS_DISABLE_FILE_UPLOAD,
+        YOPASS_DISABLE_QR_CODE:
+          process.env.YOPASS_DISABLE_QR_CODE
       },
     },
     server: {


### PR DESCRIPTION
Added two new environment variables/flags:
- YOPASS_DISABLE_FILE_UPLOAD: disables the route to the upload endpoint in the frontend and removes the button linking to the upload-page from home. Note that the respective API endpoint is still available.
- YOPASS_DISABLE_QR_CODE: disables the display of the secret as a QR-code (frontend-only feature).